### PR TITLE
Updated Jsextensions.md

### DIFF
--- a/Jsextensions.md
+++ b/Jsextensions.md
@@ -1,25 +1,21 @@
 # JS extension. 
 
-Javascript extensions are pure javascript extensions that are loaded on the browser side. 
-
+Contrary to general IPython extensions, Jupyter notebook extensions are written in javascript (or css).
 They are used to change the behaviour, functionality and UI of the Jupyter notebook. 
 
-Most of the time, you  should install *nbextensions* in the directory of the same name, either system wide. You can also install *nbextensions* on your user profile. Most nbextensions provide the documentation to indicate how they should be installed.
+Most of the time, you  should install *nbextensions* in the directory of the same name, either system wide or in your user profile. Most nbextensions provide the documentation to indicate how they should be installed.
 
 ## Activating nbextensions
 
-This part describe how to decide which nbextensions are loaded. If you are an end-user, and not interested in developing your own nbextension then you can skip this section.
+This part describe how to decide which nbextensions are loaded. If you are an end-user, and not interested in developing your own nbextension, you can skip this section.
 
+`Nbextension` can easily be loaded using their name, if
 
-`Nbextension` can be loaded by provding only their name, but to meet this contidion the shoud follow the following criteria.
-
-  - Install in one of the local, or global `nbextension` folder
-  - Their entry point should be named `<extensionname>.js`
-  - The extension should define an AMD module definition that exposes the method `load_ipython_extension` which takes not aguments.
-
+  - they are installed in one of the local, or global `nbextension` folder
+  - their entry point is named `<extensionname>.js`
+  - the extension defines an AMD module definition that exposes the method `load_ipython_extension`
 
 Here is a minimal example of AMD extension.
-
 
 ```javascript
 define(function(){
@@ -33,41 +29,42 @@ define(function(){
   };
 })
 ```
+Without further doing, the extension can be dynamically loaded inside of a Jupiter notebook:
 
+```javascript
+%%javascript
+IPython.load_extensions('custom_shortcuts');
+```
 
-To decide which extension will be loaded, Jupyter notebook will look at its configuration, and in particular to the value of the `load_extensions` key.
-To decide which extension will be loaded, Jupyter notebook will look at its configuration, and in particular to the value of the `load_extensions` key.
-
-Yo see the current value of the config in a noteobook, open an IPython  notebook, andtype the following in a console: 
+To load the extension automatically on start up, the IPython configuration has to be modified. 
+To see the current value of the config in a noteobook, open a Jupiter notebook, and type the following in the javascript console of your browser: 
 
 ```javascript
 IPython.notebook.config
 ```
 
 The value should be something like `ConfigSection {section_name: "notebook", base_url: "/", data: Object, …}`.
- 
-This give you access to the `config` object which handles loading, and updating the config. By default  the config should be empty. Access the `data` attribute to check it: 
+If no extensions are installed, the `data` attribute (``IPython.notebook.config.data``) should be empty.
 
-```
-var data = IPython.notebook.config.data
-data
-```
+By updating the config, we can register a new extension to be loaded on start up.
 
-Responds with `Object {}` in my case.
-
-Let's update the config 
+First, the new config value is created:
 ```
 var new_data = {"my_ext":true}
 ```
+The value assigned to `"my_ext"` should be non-`null`. Setting the value to `null` would remove the key from the configuration object. However, to keep everthing clear and clean, `true` should be used.
 
-Here the value assigned to `"my_ext"` shoudl be non-`null`. Setting the value to `null` would remove the key form the configuration object. The exact object stored does not matter as long as it is not null.
-
-And update the config with the new value :
+To actually update the config file, the update function of the config object has to called:
 
 ```
 IPython.notebook.config.update(new_data)
 ```
 
+Or as a one-liner:
+
+```
+IPython.notebook.config.update({"my_ext":true})
+```
 
 
 The config is technically store as a json object in  `~/.ipython/profile_default/nbconfig/notebook.json`
@@ -77,11 +74,11 @@ For example in  our case :
 ```
 // notebook.json
 {
-  "load_extensions": {"my_ext":true}
+  {"my_ext":true}
 }
 ```
 
-You should not update this file manually. It can be used by extension authors to modify configuration programatically. Extensions authors can also provide convenience methods to activate extensions. 
+You should not update this file manually as it can be used by extension authors to modify configuration programatically. Extensions authors can also provide more convienint methods to activate extensions. 
 
 
 


### PR DESCRIPTION
Corrected a few language issues and resolved some unclear points

However, I am unsure about the importance of the load_extension-keyword inside the notebook.json file. The way it was originally described (and still is) in this doc, this keyword would not be added to the config. However, everything seems to work without it.
